### PR TITLE
feat: adds support for cosmiconfig file for mock operation state

### DIFF
--- a/.changeset/little-crews-relax.md
+++ b/.changeset/little-crews-relax.md
@@ -1,0 +1,7 @@
+---
+'@apollo-mock-operations/codegen-plugin': minor
+---
+
+Adds support for mock operation state config file. The config file can be in any format supported by
+cosmiconfig including typescript. A typing has also been included (`OperationStateConfig`) for the
+config file if a `.ts` config file is provided (this is recommended).

--- a/examples/with-nextjs/apolloMock.config.ts
+++ b/examples/with-nextjs/apolloMock.config.ts
@@ -1,0 +1,17 @@
+import { OperationStateConfig } from '@apollo-mock-operations/codegen-plugin';
+import { Query, Mutation } from './src/typings/generated';
+
+const config: OperationStateConfig<Query, Mutation> = {
+  operationState: {
+    book: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR', 'LOADING'],
+    booksByAuthorId: ['SUCCESS'],
+    users: ['SUCCESS', 'LOADING', 'NETWORK_ERROR', 'GQL_ERROR'],
+    user: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR'],
+    createUser: ['SUCCESS', 'GQL_ERROR'],
+    deleteUser: ['SUCCESS'],
+    books: ['SUCCESS'],
+  },
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;

--- a/examples/with-nextjs/codegen.ts
+++ b/examples/with-nextjs/codegen.ts
@@ -7,32 +7,7 @@ const config: CodegenConfig = {
   hooks: { afterAllFileWrite: ['prettier --write'] },
   generates: {
     'src/typings/generated.d.ts': {
-      plugins: [
-        {
-          add: {
-            content: ['declare global {'],
-          },
-        },
-        {
-          add: {
-            placement: 'append',
-            content: '}',
-          },
-        },
-        'typescript',
-        {
-          '@apollo-mock-operations/codegen-plugin': {
-            operationState: {
-              book: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR', 'LOADING'],
-              booksByAuthorId: ['SUCCESS'],
-              users: ['SUCCESS', 'LOADING', 'NETWORK_ERROR', 'GQL_ERROR'],
-              user: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR'],
-              createUser: ['SUCCESS', 'GQL_ERROR'],
-              deleteUser: ['SUCCESS'],
-            },
-          },
-        },
-      ],
+      plugins: ['typescript', '@apollo-mock-operations/codegen-plugin'],
     },
     'src/lib/mocks/introspection.json': {
       plugins: ['introspection'],

--- a/examples/with-nextjs/src/lib/mocks/builder.ts
+++ b/examples/with-nextjs/src/lib/mocks/builder.ts
@@ -1,4 +1,5 @@
 import { MockGQLOperations } from '@apollo-mock-operations/core';
+import { MockOperations, OperationModels } from '../../typings/generated';
 import introspectionResult from './introspection.json';
 
 export const mockInstance = new MockGQLOperations<MockOperations, OperationModels>({

--- a/examples/with-nextjs/src/typings/generated.d.ts
+++ b/examples/with-nextjs/src/typings/generated.d.ts
@@ -1,189 +1,316 @@
 import { GraphQLError, GraphQLResolveInfo } from 'graphql';
-declare global {
-  export type Maybe<T> = T | null;
-  export type InputMaybe<T> = Maybe<T>;
-  export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-  export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-    [SubKey in K]?: Maybe<T[SubKey]>;
-  };
-  export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-  export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
-    [_ in K]?: never;
-  };
-  export type Incremental<T> =
-    | T
-    | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
-  /** All built-in and custom scalars, mapped to their actual values */
-  export type Scalars = {
-    ID: { input: string; output: string };
-    String: { input: string; output: string };
-    Boolean: { input: boolean; output: boolean };
-    Int: { input: number; output: number };
-    Float: { input: number; output: number };
-  };
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
+  [_ in K]?: never;
+};
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+};
 
-  export type Address = {
+export type Address = {
+  __typename?: 'Address';
+  addressLineOne: Scalars['String']['output'];
+  addressLineTwo?: Maybe<Scalars['String']['output']>;
+  city: Scalars['String']['output'];
+  state: Scalars['String']['output'];
+  zip: Scalars['String']['output'];
+};
+
+export type Book = {
+  __typename?: 'Book';
+  author?: Maybe<User>;
+  authorId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  numPages: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type CreateBookInput = {
+  authorId: Scalars['ID']['input'];
+  numPages: Scalars['Int']['input'];
+  title: Scalars['String']['input'];
+};
+
+export type CreateUserInput = {
+  email: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createBook: Book;
+  createUser: User;
+  deleteBook?: Maybe<Book>;
+  deleteUser?: Maybe<User>;
+};
+
+export type MutationCreateBookArgs = {
+  input: CreateBookInput;
+};
+
+export type MutationCreateUserArgs = {
+  input: CreateUserInput;
+};
+
+export type MutationDeleteBookArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type MutationDeleteUserArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  book?: Maybe<Book>;
+  books: Array<Book>;
+  booksByAuthorId?: Maybe<Array<Book>>;
+  user?: Maybe<User>;
+  users: Array<User>;
+};
+
+export type QueryBookArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type QueryBooksByAuthorIdArgs = {
+  authorId: Scalars['ID']['input'];
+};
+
+export type QueryUserArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type User = {
+  __typename?: 'User';
+  address?: Maybe<Array<Address>>;
+  books?: Maybe<Array<Book>>;
+  email: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type GraphqlError = { graphQLError?: GraphQLError };
+export type NetworkError = { networkError?: Error };
+export type OperationLoading = { loading?: boolean };
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult | GraphqlError | NetworkError | OperationLoading;
+
+type ResolverType<TResult, TArgs> = Record<
+  keyof TResult,
+  ResolverFn<TResult[keyof TResult], {}, {}, TArgs>
+>;
+
+export type BookOperationArgs = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+export type BookOperationResult = {
+  __typename?: 'Book';
+  id: string;
+  title: string;
+  numPages: number;
+  authorId: string;
+} | null;
+
+export type BookOperation = {
+  book: {
+    type: 'Query';
+    resolver: ResolverFn<BookOperationResult, any, any, BookOperationArgs>;
+    state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR' | 'LOADING';
+  };
+};
+
+export type BooksByAuthorIdOperationArgs = Exact<{
+  authorId: Scalars['ID']['input'];
+}>;
+
+export type BooksByAuthorIdOperationResult = Array<{
+  __typename?: 'Book';
+  id: string;
+  title: string;
+  numPages: number;
+  authorId: string;
+}> | null;
+
+export type BooksByAuthorIdOperation = {
+  booksByAuthorId: {
+    type: 'Query';
+    resolver: ResolverFn<BooksByAuthorIdOperationResult, any, any, BooksByAuthorIdOperationArgs>;
+    state: 'SUCCESS';
+  };
+};
+
+export type BooksOperationArgs = Exact<{ [key: string]: never }>;
+
+export type BooksOperationResult = Array<{
+  __typename?: 'Book';
+  id: string;
+  title: string;
+  numPages: number;
+  authorId: string;
+}>;
+
+export type BooksOperation = {
+  books: {
+    type: 'Query';
+    resolver: ResolverFn<BooksOperationResult, any, any, BooksOperationArgs>;
+    state: 'SUCCESS';
+  };
+};
+
+export type CreateUserOperationArgs = Exact<{
+  input: CreateUserInput;
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+export type CreateUserOperationResult = {
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
     __typename?: 'Address';
-    addressLineOne: Scalars['String']['output'];
-    addressLineTwo?: Maybe<Scalars['String']['output']>;
-    city: Scalars['String']['output'];
-    state: Scalars['String']['output'];
-    zip: Scalars['String']['output'];
-  };
-
-  export type Book = {
-    __typename?: 'Book';
-    author?: Maybe<User>;
-    authorId: Scalars['ID']['output'];
-    id: Scalars['ID']['output'];
-    numPages: Scalars['Int']['output'];
-    title: Scalars['String']['output'];
-  };
-
-  export type CreateBookInput = {
-    authorId: Scalars['ID']['input'];
-    numPages: Scalars['Int']['input'];
-    title: Scalars['String']['input'];
-  };
-
-  export type CreateUserInput = {
-    email: Scalars['String']['input'];
-    name: Scalars['String']['input'];
-  };
-
-  export type Mutation = {
-    __typename?: 'Mutation';
-    createBook: Book;
-    createUser: User;
-    deleteBook?: Maybe<Book>;
-    deleteUser?: Maybe<User>;
-  };
-
-  export type MutationCreateBookArgs = {
-    input: CreateBookInput;
-  };
-
-  export type MutationCreateUserArgs = {
-    input: CreateUserInput;
-  };
-
-  export type MutationDeleteBookArgs = {
-    id: Scalars['ID']['input'];
-  };
-
-  export type MutationDeleteUserArgs = {
-    id: Scalars['ID']['input'];
-  };
-
-  export type Query = {
-    __typename?: 'Query';
-    book?: Maybe<Book>;
-    books: Array<Book>;
-    booksByAuthorId?: Maybe<Array<Book>>;
-    user?: Maybe<User>;
-    users: Array<User>;
-  };
-
-  export type QueryBookArgs = {
-    id: Scalars['ID']['input'];
-  };
-
-  export type QueryBooksByAuthorIdArgs = {
-    authorId: Scalars['ID']['input'];
-  };
-
-  export type QueryUserArgs = {
-    id: Scalars['ID']['input'];
-  };
-
-  export type User = {
-    __typename?: 'User';
-    address?: Maybe<Array<Address>>;
-    books?: Maybe<Array<Book>>;
-    email: Scalars['String']['output'];
-    id: Scalars['ID']['output'];
-    name: Scalars['String']['output'];
-  };
-
-  export type GraphqlError = { graphQLError?: GraphQLError };
-  export type NetworkError = { networkError?: Error };
-  export type OperationLoading = { loading?: boolean };
-  export type ResolverFn<TResult, TParent, TContext, TArgs> = (
-    parent: TParent,
-    args: TArgs,
-    context: TContext,
-    info: GraphQLResolveInfo
-  ) => Promise<TResult> | TResult | GraphqlError | NetworkError | OperationLoading;
-
-  type ResolverType<TResult, TArgs> = Record<
-    keyof TResult,
-    ResolverFn<TResult[keyof TResult], {}, {}, TArgs>
-  >;
-
-  export type BookOperationArgs = Exact<{
-    id: Scalars['ID']['input'];
-  }>;
-
-  export type BookOperationResult = {
-    __typename?: 'Book';
-    id: string;
-    title: string;
-    numPages: number;
-    authorId: string;
-  } | null;
-
-  export type BookOperation = {
-    book: {
-      type: 'Query';
-      resolver: ResolverFn<BookOperationResult, any, any, BookOperationArgs>;
-      state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR' | 'LOADING';
-    };
-  };
-
-  export type BooksByAuthorIdOperationArgs = Exact<{
-    authorId: Scalars['ID']['input'];
-  }>;
-
-  export type BooksByAuthorIdOperationResult = Array<{
-    __typename?: 'Book';
-    id: string;
-    title: string;
-    numPages: number;
-    authorId: string;
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
   }> | null;
+};
 
-  export type BooksByAuthorIdOperation = {
-    booksByAuthorId: {
-      type: 'Query';
-      resolver: ResolverFn<BooksByAuthorIdOperationResult, any, any, BooksByAuthorIdOperationArgs>;
-      state: 'SUCCESS';
-    };
+export type CreateUserOperation = {
+  createUser: {
+    type: 'Mutation';
+    resolver: ResolverFn<CreateUserOperationResult, any, any, CreateUserOperationArgs>;
+    state: 'SUCCESS' | 'GQL_ERROR';
   };
+};
 
-  export type BooksOperationArgs = Exact<{ [key: string]: never }>;
+export type DeleteUserOperationArgs = Exact<{
+  id: Scalars['ID']['input'];
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
 
-  export type BooksOperationResult = Array<{
-    __typename?: 'Book';
-    id: string;
-    title: string;
-    numPages: number;
-    authorId: string;
-  }>;
+export type DeleteUserOperationResult = {
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  }> | null;
+} | null;
 
-  export type BooksOperation = {
-    books: {
-      type: 'Query';
-      resolver: ResolverFn<BooksOperationResult, any, any, BooksOperationArgs>;
-      state: 'SUCCESS';
-    };
+export type DeleteUserOperation = {
+  deleteUser: {
+    type: 'Mutation';
+    resolver: ResolverFn<DeleteUserOperationResult, any, any, DeleteUserOperationArgs>;
+    state: 'SUCCESS';
   };
+};
 
-  export type CreateUserOperationArgs = Exact<{
-    input: CreateUserInput;
-    includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
-  }>;
+export type UserOperationArgs = Exact<{
+  id: Scalars['ID']['input'];
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
 
-  export type CreateUserOperationResult = {
+export type UserOperationResult = {
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  }> | null;
+} | null;
+
+export type UserOperation = {
+  user: {
+    type: 'Query';
+    resolver: ResolverFn<UserOperationResult, any, any, UserOperationArgs>;
+    state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR';
+  };
+};
+
+export type UsersOperationArgs = Exact<{
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+export type UsersOperationResult = Array<{
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  }> | null;
+}>;
+
+export type UsersOperation = {
+  users: {
+    type: 'Query';
+    resolver: ResolverFn<UsersOperationResult, any, any, UsersOperationArgs>;
+    state: 'SUCCESS' | 'LOADING' | 'NETWORK_ERROR' | 'GQL_ERROR';
+  };
+};
+
+export type QueryOperations = BookOperation &
+  BooksByAuthorIdOperation &
+  BooksOperation &
+  UserOperation &
+  UsersOperation;
+
+export type MutationOperations = CreateUserOperation & DeleteUserOperation;
+
+export type MockOperations = {
+  Query: QueryOperations;
+  Mutation: MutationOperations;
+};
+
+export type AddressModel = {
+  Address: {
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  };
+};
+
+export type BookModel = {
+  Book: { __typename?: 'Book'; id: string; title: string; numPages: number; authorId: string };
+};
+
+export type UserModel = {
+  User: {
     __typename?: 'User';
     id: string;
     name: string;
@@ -196,137 +323,6 @@ declare global {
       zip: string;
     }> | null;
   };
+};
 
-  export type CreateUserOperation = {
-    createUser: {
-      type: 'Mutation';
-      resolver: ResolverFn<CreateUserOperationResult, any, any, CreateUserOperationArgs>;
-      state: 'SUCCESS' | 'GQL_ERROR';
-    };
-  };
-
-  export type DeleteUserOperationArgs = Exact<{
-    id: Scalars['ID']['input'];
-    includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
-  }>;
-
-  export type DeleteUserOperationResult = {
-    __typename?: 'User';
-    id: string;
-    name: string;
-    email: string;
-    address?: Array<{
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    }> | null;
-  } | null;
-
-  export type DeleteUserOperation = {
-    deleteUser: {
-      type: 'Mutation';
-      resolver: ResolverFn<DeleteUserOperationResult, any, any, DeleteUserOperationArgs>;
-      state: 'SUCCESS';
-    };
-  };
-
-  export type UserOperationArgs = Exact<{
-    id: Scalars['ID']['input'];
-    includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
-  }>;
-
-  export type UserOperationResult = {
-    __typename?: 'User';
-    id: string;
-    name: string;
-    email: string;
-    address?: Array<{
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    }> | null;
-  } | null;
-
-  export type UserOperation = {
-    user: {
-      type: 'Query';
-      resolver: ResolverFn<UserOperationResult, any, any, UserOperationArgs>;
-      state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR';
-    };
-  };
-
-  export type UsersOperationArgs = Exact<{
-    includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
-  }>;
-
-  export type UsersOperationResult = Array<{
-    __typename?: 'User';
-    id: string;
-    name: string;
-    email: string;
-    address?: Array<{
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    }> | null;
-  }>;
-
-  export type UsersOperation = {
-    users: {
-      type: 'Query';
-      resolver: ResolverFn<UsersOperationResult, any, any, UsersOperationArgs>;
-      state: 'SUCCESS' | 'LOADING' | 'NETWORK_ERROR' | 'GQL_ERROR';
-    };
-  };
-
-  export type QueryOperations = BookOperation &
-    BooksByAuthorIdOperation &
-    BooksOperation &
-    UserOperation &
-    UsersOperation;
-
-  export type MutationOperations = CreateUserOperation & DeleteUserOperation;
-
-  export type MockOperations = {
-    Query: QueryOperations;
-    Mutation: MutationOperations;
-  };
-
-  export type AddressModel = {
-    Address: {
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    };
-  };
-
-  export type BookModel = {
-    Book: { __typename?: 'Book'; id: string; title: string; numPages: number; authorId: string };
-  };
-
-  export type UserModel = {
-    User: {
-      __typename?: 'User';
-      id: string;
-      name: string;
-      email: string;
-      address?: Array<{
-        __typename?: 'Address';
-        addressLineOne: string;
-        city: string;
-        state: string;
-        zip: string;
-      }> | null;
-    };
-  };
-
-  export type OperationModels = AddressModel & BookModel & UserModel;
-}
+export type OperationModels = AddressModel & BookModel & UserModel;

--- a/examples/with-vite/apolloMock.config.ts
+++ b/examples/with-vite/apolloMock.config.ts
@@ -1,0 +1,14 @@
+import { OperationStateConfig } from '@apollo-mock-operations/codegen-plugin';
+
+const config: OperationStateConfig = {
+  operationState: {
+    book: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR', 'LOADING'],
+    booksByAuthorId: ['SUCCESS'],
+    users: ['SUCCESS', 'LOADING', 'NETWORK_ERROR', 'GQL_ERROR'],
+    user: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR'],
+    createUser: ['SUCCESS', 'GQL_ERROR'],
+    deleteUser: ['SUCCESS'],
+  },
+};
+
+export default config;

--- a/examples/with-vite/codegen.cjs
+++ b/examples/with-vite/codegen.cjs
@@ -5,32 +5,7 @@ const config = {
   hooks: { afterAllFileWrite: ['prettier --write'] },
   generates: {
     'src/typings/generated.d.ts': {
-      plugins: [
-        {
-          add: {
-            content: ['declare global {']
-          }
-        },
-        {
-          add: {
-            placement: 'append',
-            content: '}'
-          }
-        },
-        'typescript',
-        {
-          '@apollo-mock-operations/codegen-plugin': {
-            operationState: {
-              book: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR', 'LOADING'],
-              booksByAuthorId: ['SUCCESS'],
-              users: ['SUCCESS', 'LOADING', 'NETWORK_ERROR', 'GQL_ERROR'],
-              user: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR'],
-              createUser: ['SUCCESS', 'GQL_ERROR'],
-              deleteUser: ['SUCCESS']
-            }
-          }
-        },
-      ]
+      plugins: ['typescript', '@apollo-mock-operations/codegen-plugin']
     },
     'src/lib/mocks/introspection.json': {
       plugins: ['introspection']

--- a/examples/with-vite/src/lib/mocks/builder.ts
+++ b/examples/with-vite/src/lib/mocks/builder.ts
@@ -1,5 +1,6 @@
 import { MockGQLOperations } from '@apollo-mock-operations/core';
 import introspectionResult from './introspection.json';
+import { MockOperations, OperationModels } from '../../typings/generated';
 
 export const mockBuilder = new MockGQLOperations<
   MockOperations,

--- a/examples/with-vite/src/typings/generated.d.ts
+++ b/examples/with-vite/src/typings/generated.d.ts
@@ -1,183 +1,316 @@
 import { GraphQLError, GraphQLResolveInfo } from 'graphql';
-declare global {
-  export type Maybe<T> = T | null;
-  export type InputMaybe<T> = Maybe<T>;
-  export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-  export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-    [SubKey in K]?: Maybe<T[SubKey]>;
-  };
-  export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-  /** All built-in and custom scalars, mapped to their actual values */
-  export type Scalars = {
-    ID: string;
-    String: string;
-    Boolean: boolean;
-    Int: number;
-    Float: number;
-  };
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
+  [_ in K]?: never;
+};
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+};
 
-  export type Address = {
+export type Address = {
+  __typename?: 'Address';
+  addressLineOne: Scalars['String']['output'];
+  addressLineTwo?: Maybe<Scalars['String']['output']>;
+  city: Scalars['String']['output'];
+  state: Scalars['String']['output'];
+  zip: Scalars['String']['output'];
+};
+
+export type Book = {
+  __typename?: 'Book';
+  author?: Maybe<User>;
+  authorId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  numPages: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type CreateBookInput = {
+  authorId: Scalars['ID']['input'];
+  numPages: Scalars['Int']['input'];
+  title: Scalars['String']['input'];
+};
+
+export type CreateUserInput = {
+  email: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createBook: Book;
+  createUser: User;
+  deleteBook?: Maybe<Book>;
+  deleteUser?: Maybe<User>;
+};
+
+export type MutationCreateBookArgs = {
+  input: CreateBookInput;
+};
+
+export type MutationCreateUserArgs = {
+  input: CreateUserInput;
+};
+
+export type MutationDeleteBookArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type MutationDeleteUserArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  book?: Maybe<Book>;
+  books: Array<Book>;
+  booksByAuthorId?: Maybe<Array<Book>>;
+  user?: Maybe<User>;
+  users: Array<User>;
+};
+
+export type QueryBookArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type QueryBooksByAuthorIdArgs = {
+  authorId: Scalars['ID']['input'];
+};
+
+export type QueryUserArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type User = {
+  __typename?: 'User';
+  address?: Maybe<Array<Address>>;
+  books?: Maybe<Array<Book>>;
+  email: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type GraphqlError = { graphQLError?: GraphQLError };
+export type NetworkError = { networkError?: Error };
+export type OperationLoading = { loading?: boolean };
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult | GraphqlError | NetworkError | OperationLoading;
+
+type ResolverType<TResult, TArgs> = Record<
+  keyof TResult,
+  ResolverFn<TResult[keyof TResult], {}, {}, TArgs>
+>;
+
+export type BookOperationArgs = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+export type BookOperationResult = {
+  __typename?: 'Book';
+  id: string;
+  title: string;
+  numPages: number;
+  authorId: string;
+} | null;
+
+export type BookOperation = {
+  book: {
+    type: 'Query';
+    resolver: ResolverFn<BookOperationResult, any, any, BookOperationArgs>;
+    state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR' | 'LOADING';
+  };
+};
+
+export type BooksByAuthorIdOperationArgs = Exact<{
+  authorId: Scalars['ID']['input'];
+}>;
+
+export type BooksByAuthorIdOperationResult = Array<{
+  __typename?: 'Book';
+  id: string;
+  title: string;
+  numPages: number;
+  authorId: string;
+}> | null;
+
+export type BooksByAuthorIdOperation = {
+  booksByAuthorId: {
+    type: 'Query';
+    resolver: ResolverFn<BooksByAuthorIdOperationResult, any, any, BooksByAuthorIdOperationArgs>;
+    state: 'SUCCESS';
+  };
+};
+
+export type BooksOperationArgs = Exact<{ [key: string]: never }>;
+
+export type BooksOperationResult = Array<{
+  __typename?: 'Book';
+  id: string;
+  title: string;
+  numPages: number;
+  authorId: string;
+}>;
+
+export type BooksOperation = {
+  books: {
+    type: 'Query';
+    resolver: ResolverFn<BooksOperationResult, any, any, BooksOperationArgs>;
+    state: 'SUCCESS';
+  };
+};
+
+export type CreateUserOperationArgs = Exact<{
+  input: CreateUserInput;
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+export type CreateUserOperationResult = {
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
     __typename?: 'Address';
-    addressLineOne: Scalars['String'];
-    addressLineTwo?: Maybe<Scalars['String']>;
-    city: Scalars['String'];
-    state: Scalars['String'];
-    zip: Scalars['String'];
-  };
-
-  export type Book = {
-    __typename?: 'Book';
-    author?: Maybe<User>;
-    authorId: Scalars['ID'];
-    id: Scalars['ID'];
-    numPages: Scalars['Int'];
-    title: Scalars['String'];
-  };
-
-  export type CreateBookInput = {
-    authorId: Scalars['ID'];
-    numPages: Scalars['Int'];
-    title: Scalars['String'];
-  };
-
-  export type CreateUserInput = {
-    email: Scalars['String'];
-    name: Scalars['String'];
-  };
-
-  export type Mutation = {
-    __typename?: 'Mutation';
-    createBook: Book;
-    createUser: User;
-    deleteBook?: Maybe<Book>;
-    deleteUser?: Maybe<User>;
-  };
-
-  export type MutationCreateBookArgs = {
-    input: CreateBookInput;
-  };
-
-  export type MutationCreateUserArgs = {
-    input: CreateUserInput;
-  };
-
-  export type MutationDeleteBookArgs = {
-    id: Scalars['ID'];
-  };
-
-  export type MutationDeleteUserArgs = {
-    id: Scalars['ID'];
-  };
-
-  export type Query = {
-    __typename?: 'Query';
-    book?: Maybe<Book>;
-    books: Array<Book>;
-    booksByAuthorId?: Maybe<Array<Book>>;
-    user?: Maybe<User>;
-    users: Array<User>;
-  };
-
-  export type QueryBookArgs = {
-    id: Scalars['ID'];
-  };
-
-  export type QueryBooksByAuthorIdArgs = {
-    authorId: Scalars['ID'];
-  };
-
-  export type QueryUserArgs = {
-    id: Scalars['ID'];
-  };
-
-  export type User = {
-    __typename?: 'User';
-    address?: Maybe<Array<Address>>;
-    books?: Maybe<Array<Book>>;
-    email: Scalars['String'];
-    id: Scalars['ID'];
-    name: Scalars['String'];
-  };
-
-  export type GraphqlError = { graphQLError?: GraphQLError };
-  export type NetworkError = { networkError?: Error };
-  export type OperationLoading = { loading?: boolean };
-  export type ResolverFn<TResult, TParent, TContext, TArgs> = (
-    parent: TParent,
-    args: TArgs,
-    context: TContext,
-    info: GraphQLResolveInfo
-  ) => Promise<TResult> | TResult | GraphqlError | NetworkError | OperationLoading;
-
-  type ResolverType<TResult, TArgs> = Record<
-    keyof TResult,
-    ResolverFn<TResult[keyof TResult], {}, {}, TArgs>
-  >;
-
-  export type BookOperationArgs = Exact<{
-    id: Scalars['ID'];
-  }>;
-
-  export type BookOperationResult = {
-    __typename?: 'Book';
-    id: string;
-    title: string;
-    numPages: number;
-    authorId: string;
-  } | null;
-
-  export type BookOperation = {
-    book: {
-      type: 'Query';
-      resolver: ResolverFn<BookOperationResult, any, any, BookOperationArgs>;
-      state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR' | 'LOADING';
-    };
-  };
-
-  export type BooksByAuthorIdOperationArgs = Exact<{
-    authorId: Scalars['ID'];
-  }>;
-
-  export type BooksByAuthorIdOperationResult = Array<{
-    __typename?: 'Book';
-    id: string;
-    title: string;
-    numPages: number;
-    authorId: string;
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
   }> | null;
+};
 
-  export type BooksByAuthorIdOperation = {
-    booksByAuthorId: {
-      type: 'Query';
-      resolver: ResolverFn<BooksByAuthorIdOperationResult, any, any, BooksByAuthorIdOperationArgs>;
-      state: 'SUCCESS';
-    };
+export type CreateUserOperation = {
+  createUser: {
+    type: 'Mutation';
+    resolver: ResolverFn<CreateUserOperationResult, any, any, CreateUserOperationArgs>;
+    state: 'SUCCESS' | 'GQL_ERROR';
   };
+};
 
-  export type BooksOperationArgs = Exact<{ [key: string]: never }>;
+export type DeleteUserOperationArgs = Exact<{
+  id: Scalars['ID']['input'];
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
 
-  export type BooksOperationResult = Array<{
-    __typename?: 'Book';
-    id: string;
-    title: string;
-    numPages: number;
-    authorId: string;
-  }>;
+export type DeleteUserOperationResult = {
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  }> | null;
+} | null;
 
-  export type BooksOperation = {
-    books: {
-      type: 'Query';
-      resolver: ResolverFn<BooksOperationResult, any, any, BooksOperationArgs>;
-      state: 'SUCCESS';
-    };
+export type DeleteUserOperation = {
+  deleteUser: {
+    type: 'Mutation';
+    resolver: ResolverFn<DeleteUserOperationResult, any, any, DeleteUserOperationArgs>;
+    state: 'SUCCESS';
   };
+};
 
-  export type CreateUserOperationArgs = Exact<{
-    input: CreateUserInput;
-    includeAddress?: InputMaybe<Scalars['Boolean']>;
-  }>;
+export type UserOperationArgs = Exact<{
+  id: Scalars['ID']['input'];
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
 
-  export type CreateUserOperationResult = {
+export type UserOperationResult = {
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  }> | null;
+} | null;
+
+export type UserOperation = {
+  user: {
+    type: 'Query';
+    resolver: ResolverFn<UserOperationResult, any, any, UserOperationArgs>;
+    state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR';
+  };
+};
+
+export type UsersOperationArgs = Exact<{
+  includeAddress?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+export type UsersOperationResult = Array<{
+  __typename?: 'User';
+  id: string;
+  name: string;
+  email: string;
+  address?: Array<{
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  }> | null;
+}>;
+
+export type UsersOperation = {
+  users: {
+    type: 'Query';
+    resolver: ResolverFn<UsersOperationResult, any, any, UsersOperationArgs>;
+    state: 'SUCCESS' | 'LOADING' | 'NETWORK_ERROR' | 'GQL_ERROR';
+  };
+};
+
+export type QueryOperations = BookOperation &
+  BooksByAuthorIdOperation &
+  BooksOperation &
+  UserOperation &
+  UsersOperation;
+
+export type MutationOperations = CreateUserOperation & DeleteUserOperation;
+
+export type MockOperations = {
+  Query: QueryOperations;
+  Mutation: MutationOperations;
+};
+
+export type AddressModel = {
+  Address: {
+    __typename?: 'Address';
+    addressLineOne: string;
+    city: string;
+    state: string;
+    zip: string;
+  };
+};
+
+export type BookModel = {
+  Book: { __typename?: 'Book'; id: string; title: string; numPages: number; authorId: string };
+};
+
+export type UserModel = {
+  User: {
     __typename?: 'User';
     id: string;
     name: string;
@@ -190,137 +323,6 @@ declare global {
       zip: string;
     }> | null;
   };
+};
 
-  export type CreateUserOperation = {
-    createUser: {
-      type: 'Mutation';
-      resolver: ResolverFn<CreateUserOperationResult, any, any, CreateUserOperationArgs>;
-      state: 'SUCCESS' | 'GQL_ERROR';
-    };
-  };
-
-  export type DeleteUserOperationArgs = Exact<{
-    id: Scalars['ID'];
-    includeAddress?: InputMaybe<Scalars['Boolean']>;
-  }>;
-
-  export type DeleteUserOperationResult = {
-    __typename?: 'User';
-    id: string;
-    name: string;
-    email: string;
-    address?: Array<{
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    }> | null;
-  } | null;
-
-  export type DeleteUserOperation = {
-    deleteUser: {
-      type: 'Mutation';
-      resolver: ResolverFn<DeleteUserOperationResult, any, any, DeleteUserOperationArgs>;
-      state: 'SUCCESS';
-    };
-  };
-
-  export type UserOperationArgs = Exact<{
-    id: Scalars['ID'];
-    includeAddress?: InputMaybe<Scalars['Boolean']>;
-  }>;
-
-  export type UserOperationResult = {
-    __typename?: 'User';
-    id: string;
-    name: string;
-    email: string;
-    address?: Array<{
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    }> | null;
-  } | null;
-
-  export type UserOperation = {
-    user: {
-      type: 'Query';
-      resolver: ResolverFn<UserOperationResult, any, any, UserOperationArgs>;
-      state: 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'GQL_ERROR';
-    };
-  };
-
-  export type UsersOperationArgs = Exact<{
-    includeAddress?: InputMaybe<Scalars['Boolean']>;
-  }>;
-
-  export type UsersOperationResult = Array<{
-    __typename?: 'User';
-    id: string;
-    name: string;
-    email: string;
-    address?: Array<{
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    }> | null;
-  }>;
-
-  export type UsersOperation = {
-    users: {
-      type: 'Query';
-      resolver: ResolverFn<UsersOperationResult, any, any, UsersOperationArgs>;
-      state: 'SUCCESS' | 'LOADING' | 'NETWORK_ERROR' | 'GQL_ERROR';
-    };
-  };
-
-  export type QueryOperations = BookOperation &
-    BooksByAuthorIdOperation &
-    BooksOperation &
-    UserOperation &
-    UsersOperation;
-
-  export type MutationOperations = CreateUserOperation & DeleteUserOperation;
-
-  export type MockOperations = {
-    Query: QueryOperations;
-    Mutation: MutationOperations;
-  };
-
-  export type AddressModel = {
-    Address: {
-      __typename?: 'Address';
-      addressLineOne: string;
-      city: string;
-      state: string;
-      zip: string;
-    };
-  };
-
-  export type BookModel = {
-    Book: { __typename?: 'Book'; id: string; title: string; numPages: number; authorId: string };
-  };
-
-  export type UserModel = {
-    User: {
-      __typename?: 'User';
-      id: string;
-      name: string;
-      email: string;
-      address?: Array<{
-        __typename?: 'Address';
-        addressLineOne: string;
-        city: string;
-        state: string;
-        zip: string;
-      }> | null;
-    };
-  };
-
-  export type OperationModels = AddressModel & BookModel & UserModel;
-}
+export type OperationModels = AddressModel & BookModel & UserModel;

--- a/packages/codegen-plugin/package.json
+++ b/packages/codegen-plugin/package.json
@@ -48,7 +48,9 @@
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^5.0.1",
-    "@graphql-codegen/visitor-plugin-common": "^4.0.1"
+    "@graphql-codegen/visitor-plugin-common": "^4.0.1",
+    "cosmiconfig": "^8.2.0",
+    "cosmiconfig-typescript-loader": "^5.0.0"
   },
   "peerDependencies": {
     "graphql": "16.*"

--- a/packages/codegen-plugin/src/config.ts
+++ b/packages/codegen-plugin/src/config.ts
@@ -187,6 +187,34 @@ export interface ApolloMockOperationsPluginConfig extends RawDocumentsConfig {
    * ```
    */
   maybeValue?: string;
-  defaultState?: string;
+  /**
+   * @description Specify the supported state for you mocked operations. If not specified, each operation will
+   * receive a default state value of 'SUCCESS'
+   * @default null
+   *
+   * @exampleMarkdown
+   * ## Allow undefined
+   * ```ts
+   * const config: CodegenConfig = {
+   *   generates: {
+   *     'src/typings/generated.d.ts': {
+   *       plugins: [
+   *         'typescript',
+   *         {
+   *           '@apollo-mock-operations/codegen-plugin': {
+   *             operationState: {
+   *               users: ['SUCCESS', 'LOADING', 'NETWORK_ERROR', 'GQL_ERROR'],
+   *               user: ['SUCCESS', 'EMPTY', 'NETWORK_ERROR', 'GQL_ERROR'],
+   *               createUser: ['SUCCESS', 'GQL_ERROR'],
+   *               deleteUser: ['SUCCESS'],
+   *             },
+   *           },
+   *         },
+   *       ],
+   *     },
+   *   },
+   * }
+   * ```
+   */
   operationState?: Record<string, string[]>;
 }

--- a/packages/codegen-plugin/src/index.ts
+++ b/packages/codegen-plugin/src/index.ts
@@ -9,6 +9,7 @@ import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 import { LoadedFragment, optimizeOperations } from '@graphql-codegen/visitor-plugin-common';
 import { ApolloMockOperationsPluginConfig } from './config';
 import { TypeScriptDocumentsVisitor } from './visitor';
+import { OperationStateConfig } from './types';
 
 export const plugin: PluginFunction<ApolloMockOperationsPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
@@ -97,4 +98,4 @@ type ResolverType<TResult, TArgs> = Record<keyof TResult, ResolverFn<TResult[key
   };
 };
 
-export { TypeScriptDocumentsVisitor };
+export { TypeScriptDocumentsVisitor, OperationStateConfig };

--- a/packages/codegen-plugin/src/types.ts
+++ b/packages/codegen-plugin/src/types.ts
@@ -1,0 +1,14 @@
+type BaseOperation = Record<string, any> & {
+  __typename?: 'Query' | 'Mutation';
+};
+
+type OperationState<TOperation extends BaseOperation = BaseOperation> = Partial<
+  Omit<Record<keyof TOperation, string[]>, '__typename'>
+>;
+
+export type OperationStateConfig<
+  TQuery extends BaseOperation = BaseOperation,
+  TMutation extends BaseOperation = BaseOperation,
+> = {
+  operationState: OperationState<TQuery> & OperationState<TMutation>;
+};

--- a/packages/codegen-plugin/src/visitor.ts
+++ b/packages/codegen-plugin/src/visitor.ts
@@ -82,7 +82,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
     );
 
     this.operationState = this.loadOperationStateFromCosmicConfigFile() ?? config.operationState;
-    this.defaultState = config.defaultState ?? 'SUCCESS';
+    this.defaultState = 'SUCCESS';
     const preResolveTypes = getConfigValue(config.preResolveTypes, true);
     const defaultMaybeValue = 'T | null';
     const maybeValue = getConfigValue(config.maybeValue, defaultMaybeValue);
@@ -212,16 +212,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
       },
     }).search();
 
-    if (!result) {
-      return null;
-    } else {
-      if (!result?.config?.operationState) {
-        throw new Error(
-          `The provided apolloMock config file must specify an 'operationState' object.`
-        );
-      }
-      return result.config.operationState;
-    }
+    return result?.config?.operationState;
   };
 
   getOperationTypeDefinition = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,12 @@ importers:
       '@graphql-codegen/visitor-plugin-common':
         specifier: ^4.0.1
         version: 4.0.1(graphql@16.6.0)
+      cosmiconfig:
+        specifier: ^8.2.0
+        version: 8.2.0
+      cosmiconfig-typescript-loader:
+        specifier: ^5.0.0
+        version: 5.0.0(@types/node@18.17.5)(cosmiconfig@8.2.0)(typescript@5.1.6)
     devDependencies:
       '@swc/cli':
         specifier: ^0.1.62
@@ -9584,7 +9590,6 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -10510,7 +10515,6 @@ packages:
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
@@ -11096,6 +11100,20 @@ packages:
       vary: 1.1.2
     dev: false
 
+  /cosmiconfig-typescript-loader@5.0.0(@types/node@18.17.5)(cosmiconfig@8.2.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
+    engines: {node: '>=v16'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=8.2'
+      typescript: '>=4'
+    dependencies:
+      '@types/node': 18.17.5
+      cosmiconfig: 8.2.0
+      jiti: 1.19.1
+      typescript: 5.1.6
+    dev: false
+
   /cosmiconfig@6.0.0:
     resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
     engines: {node: '>=8'}
@@ -11126,7 +11144,6 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-    dev: true
 
   /cp-file@7.0.0:
     resolution: {integrity: sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==}
@@ -11904,7 +11921,6 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
-    dev: true
 
   /error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -14120,7 +14136,6 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
 
   /import-from@4.0.0:
     resolution: {integrity: sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==}
@@ -14272,7 +14287,6 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-    dev: true
 
   /is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
@@ -14929,7 +14943,6 @@ packages:
   /jiti@1.19.1:
     resolution: {integrity: sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==}
     hasBin: true
-    dev: true
 
   /jose@4.14.4:
     resolution: {integrity: sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==}
@@ -14956,7 +14969,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsdom@20.0.3:
     resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
@@ -15019,7 +15031,6 @@ packages:
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: true
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -15157,7 +15168,6 @@ packages:
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
 
   /listr2@4.0.5:
     resolution: {integrity: sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==}
@@ -16516,7 +16526,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
-    dev: true
 
   /parse-asn1@5.1.6:
     resolution: {integrity: sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==}
@@ -16563,7 +16572,6 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: true
 
   /parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
@@ -16689,7 +16697,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /pathe@1.1.1:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
@@ -17879,7 +17886,6 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
 
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -19631,7 +19637,6 @@ packages:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /ua-parser-js@1.0.35:
     resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}


### PR DESCRIPTION
Using `apolloMock` as a module name for the config file, this supports any of the following file conventions as supported by `comiconfig`. This also includes supported for typescript config file and includes a supportive type -> `OperationStateConfig`.

Supported formats:
```
 package.json,
.apolloMockrc,
.apolloMockrc.json,
.apolloMockrc.yaml,
.apolloMockrc.yml,
.apolloMockrc.js,
.apolloMockrc.ts,
apolloMock.config.js,
apolloMock.config.ts,
```